### PR TITLE
Added id tag to team section so that nav bar scoll JS can find it

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
         </section>
 
         <!-- Team -->
-        <section class="col-12 team">
+        <section class="col-12" id="team">
                 <article id="tom" class="height-half">
                     <div class="col-3 article__widget">
                         <div class="article__pic">


### PR DESCRIPTION
The 'team' section's id tag had been changed to a class (which isn't used in the CSS), meaning that the nav bar scrolling broke as it finds the element to scroll to via the ID.
