### PR TITLE
Changing removal of image filtering to only apply to banner images

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <div class="col-6 center">
       <h1 class="banner__heading">Globe Town Devs</h1>
 
-      <h2>We're Tom, Marina, Nick and Lucy, a team of student developers at Founders &amp Coders,
+      <h2 class="banner__subheading">We're Tom, Marina, Nick and Lucy, a team of student developers at Founders &amp Coders,
         a peer-led, tuition-free coding school based in London.</h2>
 
       <button class="btn color-highlight">Find Out More</button>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -17,6 +17,7 @@
 
 body {
   background-color: rgb(245, 245, 245);
+  font-family: 'Lato';
 }
 
 section, footer {
@@ -82,6 +83,10 @@ li {
 
 .banner__heading {
   font-size: 4rem;
+}
+
+.banner__subheading {
+  font-weight: 100;
 }
 
 .banner__avatar {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -92,10 +92,10 @@ li {
 .banner__avatar {
   border-radius: 100%;
   width: 25%;
-  filter:grayscale(100%);
+  filter: grayscale(100%);
 }
 
-img:hover {
+.banner__avatar:hover {
   filter:none;
 }
 


### PR DESCRIPTION
Applying it to img:hover means that it applies to all images, even the ones that didn't have any filtering applied.
