### PR TITLE
Fix scrolling to work on all browsers

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,7 +38,8 @@ function addHandlersToNavButtons() {
         var target = document.getElementById(navButtons[i].getAttribute("href").substr(1));
         /* offsetTop is the number of pixels from the nearest relatively positioned element, or
          * html element if there are none */
-        scroll(document.body, target.offsetTop, 250)
+        var elem = navigator.userAgent.indexOf("Firefox") > -1 ? document.documentElement : document.body;
+        scroll(elem, target.offsetTop, 250)
       });
     })(i);
   };

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -96,7 +96,7 @@ li {
 }
 
 .banner__avatar:hover {
-  filter:none;
+  filter: none;
 }
 
 .banner__avatar:focus,
@@ -196,9 +196,10 @@ li {
 }
 
 .fac__button {
-  width: 23%;
+  width: 40%;
   font-size: 1em;
   text-align: center;
+  margin: 0 0 2em;
 }
 
 .fac__button a {
@@ -535,7 +536,6 @@ the link to open and close the topnav (li.icon) */
 
   .fac__button {
     width: 50%;
-    margin: 0 0 2em;
   }
 
   .col-3-sm {


### PR DESCRIPTION
So browsers have a 'scrolling element' and different browsers use different elements. I think all of them use `body` but Firefox uses `html`. I have added a hacky check to the code to see if the browser is Firefox and change the element accordingly.

StackOverflow says not to check for a particular browser but to check if a particular feature is implemented. However, the [relevant property](https://developer.mozilla.org/en/docs/Web/API/document/scrollingElement) is barely implemented.

I have tested Chrome, Safari and Firefox but can't test IE or mobile browsers until this is merged.
